### PR TITLE
Implements position method in SardineChannel

### DIFF
--- a/webdav/src/main/java/no/maddin/niofs/webdav/SardineChannel.java
+++ b/webdav/src/main/java/no/maddin/niofs/webdav/SardineChannel.java
@@ -34,6 +34,7 @@ public class SardineChannel implements SeekableByteChannel {
   private WebdavPath path;
   private InputStream in;
   private ByteArrayOutputStream out;
+  private int position = 0;
 
   public SardineChannel(WebdavPath webdavPath) throws IOException {
     this.sardine = ((WebdavFileSystem)webdavPath.getFileSystem()).getSardine();
@@ -69,7 +70,9 @@ public class SardineChannel implements SeekableByteChannel {
         in = sardine.get(path.toUri().toString());
       }
       if (dst.hasArray()) {
-        return in.read(dst.array());
+    	int numBytesToRead = in.read(dst.array());
+    	position += numBytesToRead;
+		return numBytesToRead;
       }
     }
     throw new UnsupportedOperationException();
@@ -85,7 +88,8 @@ public class SardineChannel implements SeekableByteChannel {
       src.get(buf);
       os.write(buf);
     }
-
+    
+    position += len;
     return len;
   }
 
@@ -105,7 +109,7 @@ public class SardineChannel implements SeekableByteChannel {
 
   @Override
   public long position() throws IOException {
-    throw new UnsupportedOperationException();
+	  return position;
   }
 
   @Override


### PR DESCRIPTION
## Implements position method in SardineChannel

__Problem:__

NPOIFSFileSystem class from Apache POI library can be instantiated
from an InputStream.
The current input stream provided by the WebDav FileSystem relies on
the SardineChannel method implementation but this method
throws an UnsupportedOperationException.

__Fix:__

Add an internal field to keep the current position of the channel.